### PR TITLE
Fix calculation of cue types

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerViewModel.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerViewModel.java
@@ -77,14 +77,9 @@ public class FlankerViewModel extends BaseObservable {
 
   private List<StimulusCue> stimulusCueArray = new ArrayList<>();
 
-
-  // congPercent = 0.289;
-  // neutralPercent = 0.289;
-  // incongPercent = 0.421;
-
-  private int numNeut = Math.round(0.289f * FLANKER_TRIAL_RUNS);
-  private int numCong = Math.round(0.289f * FLANKER_TRIAL_RUNS);
-  private int numIncong = Math.round(0.421f * FLANKER_TRIAL_RUNS);
+  private int numNeut = Math.round(0.289f * FLANKER_TRIAL_RUNS); // 28.9%
+  private int numCong = Math.round(0.289f * FLANKER_TRIAL_RUNS); // 28.9%, same as cong
+  private int numIncong = FLANKER_TRIAL_RUNS - numNeut - numCong; // the rest, ~42.2%
 
 
   public FlankerViewModel(CompletionHandler completionHandler) {
@@ -109,10 +104,8 @@ public class FlankerViewModel extends BaseObservable {
     //add incongruent stimuli and its cues
     stimulusCueArray.addAll(StimulusCue.createIncongStimuliCueList(incongstimuliList));
 
-
-
     //randomize the stimulus cue array
-      Collections.shuffle(stimulusCueArray);
+    Collections.shuffle(stimulusCueArray);
   }
 
   /** When connected, set the live device up with a muse. */

--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/StimulusCue.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/StimulusCue.java
@@ -22,16 +22,19 @@ public class StimulusCue {
         /** Neutral Stimuli are preceded by:
             76.4% NULL cues
             23.6% RP cues, out of all RP cues 84% are the correct cue, 16% are the wrong cue.
-            For the correct RP cues, 27.7% are followed by a catch stimuli "+++++", users are instructed to tap on the side indicated by the RP cue
+            For the correct RP cues, 27.7% are followed by a catch stimuli "+++++",
+               users are instructed to tap on the side indicated by the RP cue
          **/
         List<StimulusCue> neutralStimulusCueSet = new ArrayList<>();
 
         int arraySize = neutralStimuliList.size();
         int numNullCues = Math.round(0.764f * arraySize);
-        int numWrongRPCues = Math.round(0.236f * 0.16f * arraySize);
-        int numCorNCatRPCues = Math.round(0.236f * 0.84f * 0.723f * arraySize);
-        int numCorCatchRPCues =  Math.round(0.236f * 0.84f * 0.277f * arraySize);
-
+        int numRPCues = arraySize - numNullCues; // All cues are null or RP
+        int numWrongRPCues = Math.round(0.16f * numRPCues);
+        int numRightRPCues = numRPCues - numWrongRPCues;
+        int numCorNCatRPCues = Math.round(0.723f * numRightRPCues);
+        int numCorCatchRPCues = numRightRPCues - numCorNCatRPCues;
+        assert numNullCues + numWrongRPCues + numCorNCatRPCues + numCorCatchRPCues == arraySize;
 
         /**Add null cues**/
         int index = 0;
@@ -91,15 +94,19 @@ public class StimulusCue {
         /** Congruent Stimuli are preceded by:
          76.4% NULL cues
          23.6% RP cues, out of all RP cues 84% are the correct cue, 16% are the wrong cue.
-         For the correct RP cues, 27.7% are followed by a catch stimuli "+++++", users are instructed to tap on the side indicated by the RP cue
+         For the correct RP cues, 27.7% are followed by a catch stimuli "+++++",
+            users are instructed to tap on the side indicated by the RP cue
          **/
         List<StimulusCue> congStimulusCueSet = new ArrayList<>();
 
         int arraySize = congStimuliList.size();
         int numNullCues = Math.round(0.764f * arraySize);
-        int numWrongRPCues = Math.round(0.236f * 0.16f * arraySize);
-        int numCorNCatRPCues = Math.round(0.236f * 0.84f * 0.723f * arraySize);
-        int numCorCatchRPCues =  Math.round(0.236f * 0.84f * 0.277f * arraySize);
+        int numRPCues = arraySize - numNullCues; // All cues are null or RP
+        int numWrongRPCues = Math.round(0.16f * numRPCues);
+        int numRightRPCues = numRPCues - numWrongRPCues;
+        int numCorNCatRPCues = Math.round(0.723f * numRightRPCues);
+        int numCorCatchRPCues = numRightRPCues - numCorNCatRPCues;
+        assert numNullCues + numWrongRPCues + numCorNCatRPCues + numCorCatchRPCues == arraySize;
 
 
         /**Add null cues**/
@@ -169,11 +176,12 @@ public class StimulusCue {
         int arraySize = incongStimuliList.size();
         int numNullCues = Math.round(0.475f * arraySize);
         int numWarnCues = Math.round(0.2625f * arraySize);
-        int numWrongRPCues = Math.round(0.2625f * 0.16f * arraySize);
-        int numCorNCatRPCues = Math.round(0.2625f * 0.84f * 0.723f * arraySize);
-        int numCorCatchRPCues =  Math.round(0.2625f * 0.84f * 0.277f * arraySize);
-
-
+        int numRPCues = arraySize - numNullCues - numWarnCues;
+        int numWrongRPCues = Math.round(0.16f * numRPCues);
+        int numRightRPCues = numRPCues - numWrongRPCues;
+        int numCorNCatRPCues = Math.round(0.723f * numRightRPCues);
+        int numCorCatchRPCues = numRightRPCues - numCorNCatRPCues;
+        assert numNullCues + numWarnCues + numWrongRPCues + numCorNCatRPCues + numCorCatchRPCues == arraySize;
 
         int index = 0;
 
@@ -235,8 +243,4 @@ public class StimulusCue {
         Log.d("MINT", "Created Incongruent Stimulus Cue Set: " + incongStimulusCueSet.toString());
         return incongStimulusCueSet;
     }
-
-
-
-
 }


### PR DESCRIPTION
Make sure the number of cues generated matches exactly.

This fixes an issue we had before, where round(A*n) + round(B*n) + round(C*n) != n
even when A+B+C = 1.0, due to rounding issues.
This instead calculates round(A*n) and round(B*n) then sets the third to n - round(A*n) - round(B*n)
to make sure they sum to n. 