### PR TITLE
Filter to only record RP data

### DIFF
--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerLiveRecorder.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerLiveRecorder.java
@@ -63,9 +63,13 @@ public class FlankerLiveRecorder {
   }
 
   // Handle the cue being shown.
-  public void onShowCue() {
-    timingHandler.postDelayed(alphaCollector, ALPHA_COLLECTION_END_MS);
-    timingHandler.postDelayed(betaCollector, BETA_COLLECTION_END_MS);
+  public void onShowCue(FlankerCue cue) {
+    // As per the paper, only analyze frequency data on RP cues.
+    boolean isRPCue = (cue == FlankerCue.LRP) || (cue == FlankerCue.RRP);
+    if (isRPCue) {
+      timingHandler.postDelayed(alphaCollector, ALPHA_COLLECTION_END_MS);
+      timingHandler.postDelayed(betaCollector, BETA_COLLECTION_END_MS);
+    }
   }
 
   public List<Map<String, TimeSeriesSnapshot<Double>>> getAlphaEpochs() {

--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerViewModel.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerViewModel.java
@@ -147,7 +147,7 @@ public class FlankerViewModel extends BaseObservable {
       this.stimulusIndex++;
 
     } else if (this.stage == FlankerStage.CUE) {
-      recorder.onShowCue();
+      recorder.onShowCue(this.currCue);
 
     }
 


### PR DESCRIPTION
Pass cue through to recorder, and only schedule collection tasks on LRP or RRP cues
NULL/WARN will no longer record data.