### PR TITLE
Fixed connection indicator and arrow positions

### DIFF
--- a/app/src/main/res/drawable/green_border.xml
+++ b/app/src/main/res/drawable/green_border.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <stroke
-        android:width="25dp"
+        android:width="5dp"
         android:color="#007F00" /> <!--Green-->
     <solid android:color="@android:color/transparent"/>
 

--- a/app/src/main/res/drawable/white_border.xml
+++ b/app/src/main/res/drawable/white_border.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <stroke
-        android:width="25dp"
+        android:width="5dp"
         android:color="@android:color/white"/>
     <solid android:color="@android:color/transparent"/>
 </shape>

--- a/app/src/main/res/layout/activity_flanker.xml
+++ b/app/src/main/res/layout/activity_flanker.xml
@@ -66,7 +66,9 @@
             <TextView
                 android:id="@+id/cueTextLeft"
                 android:layout_width="wrap_content"
-                android:layout_height="150dp"
+                android:layout_height="250dp"
+                android:layout_marginEnd="32dp"
+                android:layout_marginRight="32dp"
                 android:gravity="center"
                 android:keepScreenOn="true"
                 android:text="◄"
@@ -75,14 +77,13 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toLeftOf="@+id/cueTextRight"
-                app:layout_constraintTop_toTopOf="parent"
-                android:layout_marginRight="32dp"
-                android:layout_marginEnd="32dp" />
+                app:layout_constraintTop_toTopOf="parent"/>
 
             <TextView
                 android:id="@+id/cueTextRight"
                 android:layout_width="wrap_content"
-                android:layout_height="150dp"
+                android:layout_height="250dp"
+                android:layout_marginRight="13dp"
                 android:gravity="center"
                 android:keepScreenOn="true"
                 android:text="►"
@@ -108,7 +109,7 @@
             <TextView
                 android:id="@+id/arrowsText"
                 android:layout_width="wrap_content"
-                android:layout_height="140dp"
+                android:layout_height="250dp"
                 android:gravity="center"
                 android:keepScreenOn="true"
                 android:text="@{flankerVM.getArrowText()}"
@@ -123,16 +124,16 @@
         <!-- Shown on all screens. -->
         <eeg.useit.today.eegtoolkit.view.ConnectionStrengthView
             android:id="@+id/connectionStrength"
-            custom:backgroundColor="#000000"
             android:layout_width="64dp"
-            android:layout_height="32dp"
-            android:layout_marginRight="8dp"
-            android:layout_marginTop="48dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="0dp"
+            android:layout_marginTop="0dp"
             android:visibility="@{flankerVM.isConnected() ? View.VISIBLE : View.GONE}"
             app:connectionStrength="@{flankerVM.getConnectionStrength()}"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:layout_marginEnd="8dp" />
+            custom:backgroundColor="#000000"/>
 
 
 
@@ -146,7 +147,11 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginLeft="24dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="24dp"
+            android:layout_marginRight="24dp"/>
 
         <!-- Part that is visible when GREEN borders are shown. -->
         <View
@@ -158,7 +163,13 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginTop="24dp"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintVertical_bias="0.0"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="24dp"
+            android:layout_marginBottom="24dp"/>
 
 
     </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Made borders more similar to images shown in the paper:
1) Smaller width (from 25dp to 5dp)
2) Positioned away from the end of the screen (24dp padding from the side added)

Moved the cue & stim arrows back to the middle (by making the textviews bigger)
Fixed the connection status indicator back to top right, outside the borders.