### PR TITLE
Fixed CATCH stimulus to do correct left/right checking

### DIFF
--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerLiveRecorder.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerLiveRecorder.java
@@ -80,6 +80,18 @@ public class FlankerLiveRecorder {
   // At the end, check whether a tap happened and when/where.
   public void onRecordTap(FlankerCue cue, FlankerStimulus stim, TapDetails stageTap) {
     char needDirection = stim.asText().charAt(2);
+
+    // When the direction is '+', you need to tap where the cue pointed.
+    if (needDirection == '+') {
+      if (cue == FlankerCue.LRP) {
+        needDirection = '<';
+      } else if (cue == FlankerCue.RRP) {
+        needDirection = '>';
+      } else {
+        assert false : "CATCH should only happen after LRP/RRP";
+      }
+    }
+
     char gotDirection;
     if (stageTap == null) {
       gotDirection = '+';

--- a/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerStimulus.java
+++ b/app/src/main/java/ca/ubc/best/mint/museandroidapp/vm/FlankerStimulus.java
@@ -1,12 +1,8 @@
 package ca.ubc.best.mint.museandroidapp.vm;
 
-import android.util.Log;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 /** Stimuli that can be to displayed for the task. */
 enum FlankerStimulus {


### PR DESCRIPTION
It used to check for no tapping...
Now it checks for tapping on the same side as the previous cue.